### PR TITLE
feat: add security finding issue template

### DIFF
--- a/ISSUE_TEMPLATE/security-finding.yml
+++ b/ISSUE_TEMPLATE/security-finding.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         **This template is for automated scanner findings reviewed by maintainers.**
-        If you are an external reporter, please use [Private Vulnerability Reporting](https://github.com/cozystack/cozystack/security/advisories/new) instead.
+        If you are an external reporter, please use [Private Vulnerability Reporting](https://github.com/cozystack/cozystack/security/advisories/new) or email cncf-cozystack-security@lists.cncf.io instead.
   - type: input
     id: cve
     attributes:

--- a/ISSUE_TEMPLATE/security-finding.yml
+++ b/ISSUE_TEMPLATE/security-finding.yml
@@ -1,0 +1,81 @@
+name: Security Finding
+description: Report an automated security scanner finding (for maintainers)
+title: "[security] "
+labels: ["security/triage-needed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **This template is for automated scanner findings reviewed by maintainers.**
+        If you are an external reporter, please use [Private Vulnerability Reporting](https://github.com/cozystack/cozystack/security/advisories/new) instead.
+  - type: input
+    id: cve
+    attributes:
+      label: CVE ID
+      placeholder: CVE-YYYY-NNNNN
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: input
+    id: package
+    attributes:
+      label: Affected package
+      placeholder: "e.g., libcrypto3, stdlib, redis"
+    validations:
+      required: true
+  - type: input
+    id: installed_version
+    attributes:
+      label: Installed version
+      placeholder: "e.g., 3.5.1-r0"
+  - type: input
+    id: fixed_version
+    attributes:
+      label: Fixed version
+      placeholder: "e.g., 3.5.5-r0 (or 'none available')"
+  - type: textarea
+    id: affected_components
+    attributes:
+      label: Affected Cozystack components
+      placeholder: |
+        - packages/system/velero
+        - packages/apps/postgres
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: Brief description of the vulnerability and its impact
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      placeholder: |
+        - https://nvd.nist.gov/vuln/detail/CVE-YYYY-NNNNN
+        - https://github.com/advisories/GHSA-XXXX
+  - type: dropdown
+    id: triage_status
+    attributes:
+      label: Triage status
+      options:
+        - new (needs triage)
+        - confirmed
+        - false-positive
+        - accepted-risk
+        - in-progress
+        - fixed
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

Add a standard issue template for security findings (`ISSUE_TEMPLATE/security-finding.yml`).

This template is used by maintainers to track scanner findings with structured fields: CVE ID, severity, affected package, components, triage status.

Reporters of new vulnerabilities should use [Private Vulnerability Reporting](https://github.com/cozystack/cozystack/security/advisories/new) instead.

## Fields

- CVE ID, severity, package, versions
- Affected Cozystack components
- Triage status (new / confirmed / false-positive / accepted-risk / in-progress / fixed)
- References

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a standardized "Security Finding" issue template for reporting scanner findings: includes a prefilled title prefix and default security label, required fields for CVE ID, severity, affected package(s) and components, and vulnerability description, optional fields for installed/fixed versions and references, and a required triage-status dropdown with predefined workflow states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->