### PR TITLE
ci: block Co-Authored-By: <AI> trailers, recommend Assisted-By

### DIFF
--- a/.github/workflows/commit-trailers.yml
+++ b/.github/workflows/commit-trailers.yml
@@ -1,0 +1,65 @@
+name: commit-trailers
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  no-ai-coauthor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject AI Co-Authored-By trailers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) return;
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+            // Known AI coding agents that stamp a `Co-Authored-By:` trailer,
+            // matched by their vendor email or distinctive bot login. We key on
+            // bot identities (unambiguous), never on bare human names, so
+            // legitimate human co-authors are never blocked.
+            const AI_AGENTS = new RegExp([
+              'anthropic\\.com',             // Claude / Claude Code
+              'copilot-swe-agent',           // GitHub Copilot
+              '\\+copilot@users\\.noreply',  // GitHub Copilot
+              'devin-ai-integration',        // Devin (Cognition)
+              'cursoragent|@cursor\\.com',   // Cursor Agent
+              'google-labs-jules',           // Google Jules / Gemini
+              '@aider\\.chat',               // Aider
+              'windsurf|codeium',            // Windsurf / Codeium
+            ].join('|'), 'i');
+            const coAuthorLine = /^\s*co-authored-by:.*$/gim;
+            const offenders = commits
+              .filter((c) =>
+                (c.commit.message.match(coAuthorLine) || []).some((l) =>
+                  AI_AGENTS.test(l),
+                ),
+              )
+              .map((c) => c.sha.slice(0, 8));
+            if (offenders.length === 0) {
+              core.info('No AI Co-Authored-By trailers found.');
+              return;
+            }
+            const msg = [
+              `Commits ${offenders.join(', ')} carry a "Co-Authored-By: <AI agent>" trailer.`,
+              '',
+              'Under US copyright law (which governs CNCF projects) a Co-Authored-By',
+              'trailer naming an AI agent can attribute rights over the code to its',
+              'vendor. Use an informational "Assisted-By: <agent>" trailer instead — it',
+              'discloses AI assistance without transferring authorship.',
+              '',
+              'Rationale: https://github.com/anthropics/claude-code/issues/66602',
+              '',
+              'Fix: rebase and amend the trailer, then force-push.',
+              'Prevent it at source: set includeCoAuthoredBy: false in your Claude Code settings.',
+            ].join('\n');
+            await core.summary.addRaw(msg).write();
+            core.setFailed(msg);


### PR DESCRIPTION
## What

Adds an org-wide reusable workflow `commit-trailers` that **fails a PR when any of its commits carries a `Co-Authored-By: <…@anthropic.com>` trailer** (the trailer Claude Code stamps by default), and points the contributor at an informational `Assisted-By: Claude` trailer instead.

Intended to be enforced across the org via an **Organization Ruleset → "Require workflows to pass before merging"** pointing at this file (added separately by an org admin, in `Evaluate` mode first).

## Why

Under US copyright law — which governs CNCF projects — a `Co-Authored-By` trailer naming an AI agent can attribute rights over the code to its vendor. `Assisted-By:` discloses AI assistance without transferring authorship, and is the emerging convention (Linux kernel, Fedora, LLVM). See https://github.com/anthropics/claude-code/issues/66602.

## Notes

- The check keys on the `@anthropic.com` address, so it does **not** block legitimate human co-authors.
- It only gates new PRs; history is not rewritten.
- Prevent the trailer at source with the Claude Code setting `includeCoAuthoredBy: false`.
- Repos that follow Kubernetes-style rules (no trailers at all, AI disclosed in the PR body) should be excluded from the ruleset target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new automated pull request check that scans commit messages for co-author trailers associated with AI tooling/agents.
  * Pull requests with matching commit metadata will fail the check and include findings in the workflow summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->